### PR TITLE
feat: enhance shopkeeper management and image generation

### DIFF
--- a/app/api/campaigns/[id]/shop-access/route.ts
+++ b/app/api/campaigns/[id]/shop-access/route.ts
@@ -10,53 +10,49 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const campaignId = params.id
   console.log("[api/campaigns.shop-access] start", { reqId, campaignId, hasUser: !!userId, sessionId })
 
-  if (!userId) {
-    console.log("[api/campaigns.shop-access] unauthorized", { reqId })
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-  }
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
   try {
-    const raw = await req.text()
-    const body = raw ? JSON.parse(raw) : {}
-    const access_enabled = Boolean(body?.access_enabled)
-    console.log("[api/campaigns.shop-access] body", { reqId, access_enabled })
+    const { access_enabled } = (await req.json().catch(() => ({}))) as { access_enabled?: boolean }
+    if (typeof access_enabled !== "boolean") {
+      return NextResponse.json({ error: "access_enabled boolean required" }, { status: 400 })
+    }
 
     const supabase = createAdminClient()
-
-    // Check ownership by owner_id only
     const { data: campaign, error: cErr } = await supabase
       .from("campaigns")
-      .select("id, owner_id, access_enabled")
+      .select("id,name,owner_id,access_enabled")
       .eq("id", campaignId)
       .single()
 
-    if (cErr || !campaign) {
-      console.log("[api/campaigns.shop-access] not found", { reqId, error: cErr?.message })
-      return NextResponse.json({ error: "Campaign not found" }, { status: 404 })
-    }
+    console.log("[api/campaigns.shop-access] lookup", {
+      reqId,
+      found: !!campaign,
+      err: cErr?.message || null,
+      owner_id: campaign?.owner_id,
+    })
 
-    const isOwner = campaign.owner_id === userId
-    if (!isOwner) {
-      console.log("[api/campaigns.shop-access] forbidden", { reqId, owner_id: campaign.owner_id, userId })
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-    }
+    if (cErr || !campaign) return NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    if (campaign.owner_id !== userId) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
     const { data: updated, error: uErr } = await supabase
       .from("campaigns")
       .update({ access_enabled })
       .eq("id", campaignId)
-      .select("id, access_enabled")
+      .select("id,name,owner_id,access_enabled")
       .single()
 
-    if (uErr) {
-      console.error("[api/campaigns.shop-access] update error", { reqId, message: uErr.message })
-      return NextResponse.json({ error: "Failed to update access" }, { status: 500 })
-    }
+    console.log("[api/campaigns.shop-access] update", {
+      reqId,
+      err: uErr?.message || null,
+      access_enabled: updated?.access_enabled,
+    })
 
-    console.log("[api/campaigns.shop-access] done", { reqId, access_enabled: updated?.access_enabled })
-    return NextResponse.json({ campaign: { ...updated, isOwner: true } })
+    if (uErr || !updated) return NextResponse.json({ error: "Update failed" }, { status: 500 })
+
+    return NextResponse.json({ ok: true, campaign: { ...updated, isOwner: true } })
   } catch (e: any) {
     console.error("[api/campaigns.shop-access] exception", { reqId, message: e?.message })
-    return NextResponse.json({ error: e?.message || "Internal error" }, { status: 500 })
+    return NextResponse.json({ error: e?.message || "Internal Server Error" }, { status: 500 })
   }
 }

--- a/app/api/shopkeepers/[id]/route.ts
+++ b/app/api/shopkeepers/[id]/route.ts
@@ -4,6 +4,7 @@ import { createAdminClient } from "@/lib/supabaseAdmin"
 
 const rid = () => Math.random().toString(36).slice(2, 8)
 
+// Soft-remove a shopkeeper (owner only)
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
   const reqId = rid()
   const { userId, sessionId } = getAuth(req)
@@ -15,47 +16,33 @@ export async function DELETE(req: NextRequest, { params }: { params: { id: strin
   try {
     const supabase = createAdminClient()
 
-    // Find shopkeeper
-    const { data: sk, error: sErr } = await supabase
+    // Find shopkeeper and its campaign
+    const { data: shop, error: sErr } = await supabase
       .from("shopkeepers")
       .select("id,campaign_id,removed")
       .eq("id", shopkeeperId)
       .single()
-    if (sErr || !sk) {
-      console.log("[api/shopkeepers/:id] not found", { reqId, message: sErr?.message })
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
+    if (sErr || !shop) return NextResponse.json({ error: "Not found" }, { status: 404 })
 
-    // Check owner of campaign
     const { data: campaign, error: cErr } = await supabase
       .from("campaigns")
       .select("id,owner_id")
-      .eq("id", sk.campaign_id)
+      .eq("id", shop.campaign_id)
       .single()
-    if (cErr || !campaign) {
-      console.log("[api/shopkeepers/:id] campaign not found", { reqId, message: cErr?.message })
-      return NextResponse.json({ error: "Campaign missing" }, { status: 404 })
-    }
-    const isOwner = campaign.owner_id === userId
-    if (!isOwner) {
-      console.log("[api/shopkeepers/:id] forbidden", { reqId, owner_id: campaign.owner_id, userId })
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-    }
+    if (cErr || !campaign) return NextResponse.json({ error: "Campaign not found" }, { status: 404 })
 
-    // Soft-remove
-    const { data: upd, error: uErr } = await supabase
+    if (campaign.owner_id !== userId) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+    const { data: updated, error: uErr } = await supabase
       .from("shopkeepers")
       .update({ removed: true, removed_at: new Date().toISOString() })
       .eq("id", shopkeeperId)
       .select("id,removed,removed_at")
       .single()
-    if (uErr) {
-      console.error("[api/shopkeepers/:id] update error", { reqId, message: uErr.message })
-      return NextResponse.json({ error: "Failed to remove" }, { status: 500 })
-    }
+    if (uErr || !updated) return NextResponse.json({ error: "Update failed" }, { status: 500 })
 
-    console.log("[api/shopkeepers/:id] removed", { reqId, id: upd.id })
-    return NextResponse.json({ ok: true, id: upd.id, removed: upd.removed, removed_at: upd.removed_at })
+    console.log("[api/shopkeepers/:id] DELETE done", { reqId, id: updated.id, removed: updated.removed })
+    return NextResponse.json({ ok: true, id: updated.id })
   } catch (e: any) {
     console.error("[api/shopkeepers/:id] exception", { reqId, message: e?.message })
     return NextResponse.json({ error: e?.message || "Internal Server Error" }, { status: 500 })

--- a/app/api/shopkeepers/quick-seed/route.ts
+++ b/app/api/shopkeepers/quick-seed/route.ts
@@ -1,0 +1,143 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { getAuth } from "@clerk/nextjs/server"
+import { createAdminClient } from "@/lib/supabaseAdmin"
+
+const rid = () => Math.random().toString(36).slice(2, 8)
+
+export async function POST(req: NextRequest) {
+  const reqId = rid()
+  const { userId, sessionId } = getAuth(req)
+  console.log("[api/shopkeepers.quick-seed] start", { reqId, hasUser: !!userId, sessionId })
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  try {
+    const { campaignId } = (await req.json().catch(() => ({}))) as { campaignId?: string }
+    if (!campaignId) return NextResponse.json({ error: "campaignId required" }, { status: 400 })
+
+    const supabase = createAdminClient()
+
+    // Owner check
+    const { data: campaign, error: cErr } = await supabase
+      .from("campaigns")
+      .select("id,owner_id")
+      .eq("id", campaignId)
+      .single()
+    if (cErr || !campaign) return NextResponse.json({ error: "Campaign not found" }, { status: 404 })
+    if (campaign.owner_id !== userId) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+    // Ensure there are zero active shopkeepers before seeding (as requested)
+    const { count: activeCount } = await supabase
+      .from("shopkeepers")
+      .select("id", { count: "exact", head: true })
+      .eq("campaign_id", campaignId)
+      .eq("removed", false)
+    if ((activeCount ?? 0) > 0) {
+      return NextResponse.json({ ok: false, message: "Campaign already has shopkeepers" }, { status: 400 })
+    }
+
+    // Pick 5 random active shopkeepers from the global pool (any campaign), to clone
+    const { data: sourceShops, error: sErr } = await supabase
+      .from("shopkeepers")
+      .select("id,name,race,age,alignment,quote,description,shop_type,token_id")
+      .eq("removed", false)
+      .order("created_at", { ascending: false })
+      .limit(100) // sample pool
+    if (sErr) return NextResponse.json({ error: "Failed to query source shopkeepers" }, { status: 500 })
+    if (!sourceShops?.length) return NextResponse.json({ error: "No source shopkeepers to seed from" }, { status: 400 })
+
+    // Randomly take 5 from the pool
+    const pool = [...sourceShops]
+    for (let i = pool.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[pool[i], pool[j]] = [pool[j], pool[i]]
+    }
+    const picks = pool.slice(0, Math.min(5, pool.length))
+
+    // Tokens for picks
+    const tokenIds = picks.map((p) => p.token_id).filter(Boolean) as string[]
+    let tokenById = new Map<string, { id: string; image_url: string | null; description: string | null }>()
+    if (tokenIds.length) {
+      const { data: tokens } = await supabase.from("tokens").select("id,image_url,description").in("id", tokenIds)
+      if (tokens) {
+        tokenById = new Map(
+          tokens.map((t) => [
+            String(t.id),
+            { id: String(t.id), image_url: t.image_url, description: (t as any).description ?? null },
+          ]),
+        )
+      }
+    }
+
+    // Inventories of picks
+    const pickIds = picks.map((p) => p.id)
+    const { data: invRows, error: iErr } = await supabase
+      .from("shop_inventory")
+      .select(
+        "id,shopkeeper_id,item_name,rarity,base_price,price_adjustment_percent,final_price,stock_quantity,created_at",
+      )
+      .in("shopkeeper_id", pickIds)
+    if (iErr) return NextResponse.json({ error: "Failed to query inventory for seeds" }, { status: 500 })
+
+    // Clone into target campaign
+    const created: any[] = []
+    for (const p of picks) {
+      // duplicate token row for this campaign (keep same image_url/description)
+      let newTokenId: string | null = null
+      const tok = p.token_id ? tokenById.get(String(p.token_id)) : null
+      if (tok) {
+        const { data: newTok, error: tErr } = await supabase
+          .from("tokens")
+          .insert({
+            type: "shopkeeper",
+            image_url: tok.image_url,
+            description: tok.description || "seeded image",
+            campaign_id: campaignId,
+          })
+          .select("id,image_url")
+          .single()
+        if (!tErr && newTok) newTokenId = String(newTok.id)
+      }
+
+      const { data: newShop, error: s2Err } = await supabase
+        .from("shopkeepers")
+        .insert({
+          campaign_id: campaignId,
+          name: p.name,
+          race: p.race,
+          age: p.age,
+          alignment: p.alignment,
+          quote: p.quote,
+          description: p.description,
+          shop_type: p.shop_type,
+          token_id: newTokenId,
+          removed: false,
+          removed_at: null,
+        })
+        .select("id,name,shop_type,token_id,created_at")
+        .single()
+      if (s2Err || !newShop) continue
+
+      const rowsForThis = (invRows || []).filter((r) => r.shopkeeper_id === p.id)
+      if (rowsForThis.length) {
+        const clones = rowsForThis.map((r) => ({
+          shopkeeper_id: newShop.id,
+          item_name: r.item_name,
+          rarity: r.rarity,
+          base_price: r.base_price,
+          price_adjustment_percent: r.price_adjustment_percent,
+          final_price: r.final_price,
+          stock_quantity: r.stock_quantity,
+        }))
+        await supabase.from("shop_inventory").insert(clones)
+      }
+
+      created.push(newShop)
+    }
+
+    console.log("[api/shopkeepers.quick-seed] done", { reqId, created: created.length })
+    return NextResponse.json({ ok: true, created })
+  } catch (e: any) {
+    console.error("[api/shopkeepers.quick-seed] exception", { reqId, message: e?.message })
+    return NextResponse.json({ error: e?.message || "Internal Server Error" }, { status: 500 })
+  }
+}

--- a/scripts/v10-shopkeepers-removed.sql
+++ b/scripts/v10-shopkeepers-removed.sql
@@ -1,8 +1,8 @@
--- Add soft-delete flags to shopkeepers so DMs can remove without data loss
-ALTER TABLE shopkeepers
-ADD COLUMN IF NOT EXISTS removed boolean NOT NULL DEFAULT false;
+-- Add soft-delete fields to shopkeepers and ensure defaults.
+ALTER TABLE public.shopkeepers
+ADD COLUMN IF NOT EXISTS removed BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS removed_at TIMESTAMPTZ;
 
-ALTER TABLE shopkeepers
-ADD COLUMN IF NOT EXISTS removed_at timestamptz NULL;
-
-CREATE INDEX IF NOT EXISTS idx_shopkeepers_campaign_removed ON shopkeepers (campaign_id, removed);
+-- Optional helpful index
+CREATE INDEX IF NOT EXISTS idx_shopkeepers_campaign_active
+ON public.shopkeepers (campaign_id, removed);


### PR DESCRIPTION
Fix auth issue in shop-access route; add soft remove API; top up shopkeepers; generate Stability images.

#VERCEL_SKIP

shopkeepers added, working, access disabling is done, generation needs work, shops are generating though and you can add more and more to them. need to refine the prompt though I think to be more diverse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Quick-seed shopkeepers into a campaign with one click.
  - Campaign owners can remove shopkeepers (soft-delete).
- Improvements
  - Generation now tops up to a requested total (1–20) with richer image results.
  - Shopkeepers list hides removed entries; added owner controls for generate, quick add, and access toggle.
  - Added per-shopkeeper delete action and improved cards with visual accents.
  - Enhanced inventory controls UI (placeholders for future updates).
- Chores
  - Added soft-delete fields and indexing to support faster filtered queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->